### PR TITLE
Add editing for entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project provides a simple web application for tracking border crossings and
 
 - Add border crossings with date and country.
 - View all entries in a table.
+- Edit existing entries.
 - Calculate how many days were spent in each visited country for a selected period. The day of crossing counts for both countries.
 - Import and export data as a JSON file.
 - Offline support via a service worker.

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const dateInput = document.getElementById('cross-date');
 const countryInput = document.getElementById('cross-country');
 const addBtn = document.getElementById('add-btn');
+const cancelBtn = document.getElementById('cancel-btn');
 const tableBody = document.querySelector('#cross-table tbody');
 const fromInput = document.getElementById('stat-from');
 const toInput = document.getElementById('stat-to');
@@ -11,13 +12,32 @@ const exportBtn = document.getElementById('export-btn');
 const importFile = document.getElementById('import-file');
 
 let entries = loadEntries();
+let editIndex = null;
 renderTable();
 
 addBtn.addEventListener('click', () => {
   if (!dateInput.value || !countryInput.value) return;
-  entries.push({ date: dateInput.value, country: countryInput.value.trim() });
+  const data = { date: dateInput.value, country: countryInput.value.trim() };
+  if (editIndex === null) {
+    entries.push(data);
+  } else {
+    entries[editIndex] = data;
+    addBtn.textContent = 'Add';
+    cancelBtn.style.display = 'none';
+    editIndex = null;
+  }
   saveEntries();
   renderTable();
+  dateInput.value = '';
+  countryInput.value = '';
+});
+
+cancelBtn.addEventListener('click', () => {
+  editIndex = null;
+  dateInput.value = '';
+  countryInput.value = '';
+  addBtn.textContent = 'Add';
+  cancelBtn.style.display = 'none';
 });
 
 calcBtn.addEventListener('click', () => {
@@ -50,6 +70,18 @@ importFile.addEventListener('change', e => {
   reader.readAsText(file);
 });
 
+tableBody.addEventListener('click', e => {
+  if (e.target.classList.contains('edit-btn')) {
+    const index = parseInt(e.target.dataset.index, 10);
+    const entry = entries[index];
+    dateInput.value = entry.date;
+    countryInput.value = entry.country;
+    editIndex = index;
+    addBtn.textContent = 'Save';
+    cancelBtn.style.display = 'inline';
+  }
+});
+
 function loadEntries() {
   const data = localStorage.getItem('entries');
   return data ? JSON.parse(data) : [];
@@ -62,11 +94,11 @@ function saveEntries() {
 function renderTable() {
   tableBody.innerHTML = '';
   entries.sort((a, b) => a.date.localeCompare(b.date));
-  for (const e of entries) {
+  entries.forEach((e, i) => {
     const row = document.createElement('tr');
-    row.innerHTML = `<td>${e.date}</td><td>${e.country}</td>`;
+    row.innerHTML = `<td>${e.date}</td><td>${e.country}</td><td><button class="edit-btn" data-index="${i}">Edit</button></td>`;
     tableBody.appendChild(row);
-  }
+  });
 }
 
 function countDays(from, to) {

--- a/index.html
+++ b/index.html
@@ -13,13 +13,14 @@
     <label>Date: <input type="date" id="cross-date"></label>
     <label>Country: <input type="text" id="cross-country"></label>
     <button id="add-btn">Add</button>
+    <button id="cancel-btn" style="display:none">Cancel</button>
   </section>
 
   <section>
     <h2>Crossings</h2>
     <table id="cross-table">
       <thead>
-        <tr><th>Date</th><th>Country</th></tr>
+        <tr><th>Date</th><th>Country</th><th>Actions</th></tr>
       </thead>
       <tbody></tbody>
     </table>


### PR DESCRIPTION
## Summary
- allow editing saved entries
- show actions in table and cancel button in form
- document new editing feature

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683f4791812c8330b6b88530401edce7