### PR TITLE
Add residence selection and stats improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ This project provides a simple web application for tracking border crossings and
 - Counts are shown as formatted durations.
 - Import and export data as a JSON file.
 - Offline support via a service worker.
-- Optional pie chart for visualizing statistics.
+- Pie and bar charts for visualizing statistics.
+- Store a country of residence.
+- Country inputs offer suggestions based on previous entries.
+- If Poland is the residence, statistics show how many days remain outside Poland this year.
 
 ## Usage
 

--- a/index.html
+++ b/index.html
@@ -8,10 +8,14 @@
 </head>
 <body>
   <h1>Abroad Calendar Calc</h1>
+  <section id="settings-section">
+    <label>Residence: <input list="country-list" id="residence-country"></label>
+  </section>
+
   <section id="entry-form">
     <h2>Add Border Crossing</h2>
     <label>Date: <input type="date" id="cross-date"></label>
-    <label>Country: <input type="text" id="cross-country"></label>
+    <label>Country: <input list="country-list" id="cross-country"></label>
     <button id="add-btn">Add</button>
     <button id="cancel-btn" style="display:none">Cancel</button>
   </section>
@@ -50,7 +54,8 @@
     </label>
     <button id="calc-btn">Calculate</button>
     <div id="stats-result"></div>
-    <canvas id="chart" width="300" height="300"></canvas>
+    <canvas id="pie-chart" width="300" height="300"></canvas>
+    <canvas id="bar-chart" width="300" height="300"></canvas>
   </section>
 
   <section id="io-section">
@@ -59,6 +64,7 @@
     <input type="file" id="import-file" accept="application/json">
   </section>
 
+  <datalist id="country-list"></datalist>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow choosing a country of residence
- reuse known countries for input via datalist
- add pie and bar charts for stats
- show remaining days outside Poland if it is the residence

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_683f5317e1848330877c465759a7b4b2